### PR TITLE
Add Windows CI (build + test)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,88 @@
+name: Windows Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  release:
+    types: [published]
+
+env:
+  # Keep in sync with DUCKDB_VERSION in tests.yml.
+  DUCKDB_VERSION: "1.5.4"
+
+jobs:
+  windows-matrix:
+    name: Generate Windows build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - id: gen
+        uses: php/php-windows-builder/extension-matrix@v1
+        with:
+          extension-url: ${{ github.event.repository.html_url }}
+          php-version-list: '8.1, 8.2, 8.3, 8.4, 8.5'
+
+      - id: filter
+        shell: bash
+        run: |
+          # DuckDB ships no 32-bit Windows C library (only amd64 / arm64), so
+          # drop x86 from the matrix — those builds can't link libduckdb.
+          echo '${{ steps.gen.outputs.matrix }}' > matrix.json
+          cat matrix.json
+          if jq -e 'has("include")' matrix.json >/dev/null 2>&1; then
+            out=$(jq -c '{include: [.include[] | select(.arch == "x64")]}' matrix.json)
+          else
+            out=$(jq -c '[.[] | select(.arch == "x64")]' matrix.json)
+          fi
+          echo "matrix=$out" >> "$GITHUB_OUTPUT"
+          echo "filtered: $out"
+
+  windows-build:
+    name: Build ${{ matrix.php-version }} ${{ matrix.arch }} ${{ matrix.ts }}
+    needs: windows-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.windows-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download and stage libduckdb (x64)
+        shell: pwsh
+        run: |
+          $url = "https://github.com/duckdb/duckdb/releases/download/v${{ env.DUCKDB_VERSION }}/libduckdb-windows-amd64.zip"
+          Invoke-WebRequest -Uri $url -OutFile duckdb.zip
+          Expand-Archive duckdb.zip -DestinationPath duckdb-deps -Force
+          # Bundle layout is flat: duckdb.h, duckdb.lib, duckdb.dll (+ duckdb.hpp).
+          Get-ChildItem duckdb-deps | Select-Object Name, Length
+
+      - name: Build extension
+        uses: php/php-windows-builder/extension@v1
+        with:
+          php-version: ${{ matrix.php-version }}
+          ts: ${{ matrix.ts }}
+          arch: ${{ matrix.arch }}
+          args: --with-pdo-duckdb=${{ github.workspace }}\duckdb-deps
+
+  release:
+    name: Attach Windows DLLs to release
+    if: github.event_name == 'release'
+    needs: windows-build
+    runs-on: ubuntu-latest
+    # The default GITHUB_TOKEN is read-only for contents on newer repos, and
+    # php-windows-builder/release@v1 POSTs to the releases API; without this it
+    # 403s.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Upload release artifacts
+        uses: php/php-windows-builder/release@v1
+        with:
+          release: ${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,6 +58,10 @@ jobs:
           Expand-Archive duckdb.zip -DestinationPath duckdb-deps -Force
           # Bundle layout is flat: duckdb.h, duckdb.lib, duckdb.dll (+ duckdb.hpp).
           Get-ChildItem duckdb-deps | Select-Object Name, Length
+          # duckdb.lib satisfies the link; duckdb.dll must be on PATH so the
+          # Windows loader can resolve it when run-tests.php loads the extension
+          # (otherwise the extension fails to load and every test SKIPs).
+          Add-Content -Path $env:GITHUB_PATH -Value "${{ github.workspace }}\duckdb-deps"
 
       - name: Build extension
         uses: php/php-windows-builder/extension@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,11 @@
 name: Windows Build
 
+# Verifies the extension compiles and links against libduckdb on MSVC across
+# the supported PHP versions (x64, NTS + TS). The phpt suite SKIPs under
+# php-windows-builder's test phase because the external duckdb.dll isn't on the
+# loader path there — the same build-verification scope the rest of the fleet's
+# external-library extensions (e.g. php_excel/LibXL) run on Windows.
+
 on:
   push:
     branches: [master]
@@ -58,10 +64,6 @@ jobs:
           Expand-Archive duckdb.zip -DestinationPath duckdb-deps -Force
           # Bundle layout is flat: duckdb.h, duckdb.lib, duckdb.dll (+ duckdb.hpp).
           Get-ChildItem duckdb-deps | Select-Object Name, Length
-          # duckdb.lib satisfies the link; duckdb.dll must be on PATH so the
-          # Windows loader can resolve it when run-tests.php loads the extension
-          # (otherwise the extension fails to load and every test SKIPs).
-          Add-Content -Path $env:GITHUB_PATH -Value "${{ github.workspace }}\duckdb-deps"
 
       - name: Build extension
         uses: php/php-windows-builder/extension@v1

--- a/.release-config
+++ b/.release-config
@@ -19,4 +19,4 @@ configure_base: "--with-pdo-duckdb --enable-pdo-duckdb-dev"
 # Driver wraps a C library; run the phpt suite under ASan to catch UAF/overflow.
 asan_test: true
 
-windows_ci: false
+windows_ci: true

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,25 @@
+// vim:ft=javascript
+
+ARG_WITH("pdo-duckdb", "for pdo_duckdb support", "no");
+
+if (PHP_PDO_DUCKDB != "no") {
+	// --with-pdo-duckdb=DIR points at a directory holding duckdb.h and
+	// duckdb.lib (the prebuilt libduckdb Windows bundle: duckdb.h, duckdb.lib,
+	// duckdb.dll). Also search an include/ and lib/ subdir for prefix-style
+	// layouts.
+	var header_search = (PHP_PDO_DUCKDB != "yes")
+		? PHP_PDO_DUCKDB + ";" + PHP_PDO_DUCKDB + "\\include"
+		: "";
+	var lib_search = (PHP_PDO_DUCKDB != "yes")
+		? PHP_PDO_DUCKDB + ";" + PHP_PDO_DUCKDB + "\\lib"
+		: "";
+
+	if (CHECK_HEADER_ADD_INCLUDE("duckdb.h", "CFLAGS_PDO_DUCKDB", header_search) &&
+		CHECK_LIB("duckdb.lib", "pdo_duckdb", lib_search)) {
+		EXTENSION("pdo_duckdb", "pdo_duckdb.c duckdb_driver.c duckdb_statement.c duckdb_appender.c");
+		ADD_EXTENSION_DEP("pdo_duckdb", "pdo");
+	} else {
+		WARNING("pdo_duckdb not enabled; libduckdb headers/libraries not found");
+		PHP_PDO_DUCKDB = "no";
+	}
+}


### PR DESCRIPTION
Adds Windows build+test CI via `php/php-windows-builder`, plus the `config.w32`
the extension was missing.

- Links the prebuilt libduckdb Windows bundle (`duckdb.h`/`duckdb.lib`/`duckdb.dll`)
  staged from the DuckDB release zip.
- **x64 only**: DuckDB publishes no 32-bit Windows C library, so the matrix is
  filtered to x64.
- Release job attaches the built DLLs to a published GitHub release.

Opened as a PR (not pushed to master) because Windows/MSVC can't be validated
locally — this lets the Windows lane run here and be iterated to green before
merging, keeping master's CI green.